### PR TITLE
Fix bug check permission

### DIFF
--- a/application/libraries/account/Authorization.php
+++ b/application/libraries/account/Authorization.php
@@ -63,11 +63,11 @@ class Authorization
     {
         $account_permissions = array();
         $permissions = $this->CI->Acl_permission_model->get_by_account_id($account_id);
-        $this->_account_permissions_cache[$account_id] = $account_permissions;
         foreach ($permissions as $perm)
         {
             $account_permissions[] = $perm->key;
         }
+        $this->_account_permissions_cache[$account_id] = $account_permissions;
     }
 
     // Loop through and check if the account


### PR DESCRIPTION
When calling the function $this->authorization->is_permitted() more
than once, the next call can’t get the permission value (always false)
